### PR TITLE
adding a version of list-headers that render using table elements

### DIFF
--- a/src/components/list-headers-table/list-headers-table.less
+++ b/src/components/list-headers-table/list-headers-table.less
@@ -1,0 +1,21 @@
+@import '../../common/variables.less';
+tr {
+    font-weight: @table-header-font-weight;
+    color: @header-color;
+    text-align: left;
+    padding: 0 5px 8px 5px;
+    cursor: pointer;
+}
+.header-icon {
+    vertical-align: text-bottom;
+    display: inline-table;
+}
+.arrow-down:before {
+    content: "\2193";
+}
+.arrow-up:before {
+    content: "\2191";
+}
+:host {
+    display: table-header-group !important;
+}

--- a/src/components/list-headers-table/list-headers-table.spec.ts
+++ b/src/components/list-headers-table/list-headers-table.spec.ts
@@ -1,0 +1,64 @@
+import {
+    ComponentFixture,
+    TestBed
+}                       from '@angular/core/testing';
+
+import { ListHeadersTable }  from './list-headers-table';
+
+declare const beforeEach, describe, expect, it;
+
+describe('Component: ListHeadersTable', () => {
+    let fixture: ComponentFixture<ListHeadersTable>;
+    let listHeaders;
+    let element;
+
+    const initialize = () => {
+        listHeaders.headers = [
+            { label: 'display name',    property: 'displayName',    styles: { width: '23%' } },
+            { label: 'description',     property: 'description',    sortOnInit: 'desc',    styles: { width: '54%' } },
+            { label: 'modified',        property: 'lastModifiedAt', styles: { width: '23%' } }
+        ];
+        fixture.detectChanges();
+    };
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations:   [ ListHeadersTable ]
+        });
+
+        fixture = TestBed.createComponent(ListHeadersTable);
+        listHeaders = fixture.componentInstance;
+        element = fixture.nativeElement;
+        initialize();
+    });
+
+    it('should render headers', () => {
+        expect(element.querySelectorAll('th').length).toBe(3);
+    });
+
+    it('should emit on sorting', (done) => {
+        expect(listHeaders.sortedBy).toBe('description');
+        expect(listHeaders.ascOrder).toBe(false);
+        listHeaders.emitSort.subscribe((x) => {
+            expect(x.order).toBe('asc');
+            expect(x.sortBy).toBe('description');
+            done();
+        });
+        listHeaders.sort('description');
+    });
+
+    it('should sort descending if same category is chosen', (done) => {
+        let subscription1: any = listHeaders.emitSort.subscribe((x) => {
+            expect(x.order).toBe('asc');
+            expect(x.sortBy).toBe('displayName');
+            done();
+        });
+        listHeaders.sort('displayName');
+        subscription1.unsubscribe();
+        listHeaders.emitSort.subscribe((x) => {
+            expect(x.order).toBe('desc');
+            expect(x.sortBy).toBe('displayName');
+            done();
+        });
+    });
+});

--- a/src/components/list-headers-table/list-headers-table.ts
+++ b/src/components/list-headers-table/list-headers-table.ts
@@ -1,0 +1,95 @@
+import {Component, Input, Output, EventEmitter, OnInit} from '@angular/core';
+import * as _ from 'lodash';
+
+declare const require: any;
+const styles: any = require('!!css-loader!less-loader!./list-headers-table.less');
+
+/**
+ * A component which can be used as a header to a table which allows for emitting events to allow for
+ * sorting elements by attributes.
+ * 
+ * ### Simple Example
+ *
+ * ```
+ * <list-headers-table (emitSort)="sort($event)" [headers]="headers"></list-headers-table>
+ *
+ * ```
+ * 
+ * In model:
+ * ```
+ *  class Component {
+ *      public headers = [
+ *          { label: 'display name',    property: 'displayName',    styles: { width: '23%' }},
+ *          { label: 'description',     property: 'description',    styles: { width: '54%' }, sortOnInit: 'desc'},
+ *          { label: 'modified',        property: 'lastModifiedAt', styles: { width: '23%' }}
+ *      ];
+ *  }
+ * ```
+ *
+ * This will trigger sort() upon clicking on one of the header values to be sorted.
+ * 
+ * Header values are also set as headers using the interface defined in its own namespace.  Note that the default
+ * sorting criteria can be set by adding the optional `sortOnInit` property to the desired header.
+ */
+
+@Component({
+    selector: 'list-headers-table',
+    styles: [styles.toString()],
+    template: `
+        <tr>
+            <th *ngFor="let header of headers" (click)="sort(header.property)" [ngStyle]="header.styles">
+                <span class="header-title">{{(header.label || header.property) | uppercase}} </span>
+                <span class="header-icon"
+                      [ngClass]="ascOrder ? 'arrow-down' : 'arrow-up'"
+                      *ngIf="header.property && sortedBy === header.property">
+                </span>
+            </th>
+        </tr>
+    `
+})
+export class ListHeadersTable implements OnInit {
+    @Input() public headers: ListHeaders.IHeader[];
+    @Output() public emitSort = new EventEmitter();
+
+    private sortedBy: string;
+    private ascOrder: boolean;
+
+    public sort(header) {
+        if (!header) { return; }
+        if (this.sortedBy === header) {
+            this.ascOrder = !this.ascOrder;
+        } else {
+            this.ascOrder = true;
+        }
+        this.sortedBy = header;
+        this.emitSort.emit({ 
+            order: this.ascOrder ? 'asc' as ListHeaders.ascOrder : 'desc' as ListHeaders.ascOrder, 
+            sortBy: this.sortedBy 
+        });
+    }
+    
+    public ngOnInit() {
+        const sortHeader: ListHeaders.IHeader = _.find(this.headers, (header: ListHeaders.IHeader) => {
+            return header.sortOnInit;
+        }) || this.headers[0];
+        this.ascOrder = sortHeader.sortOnInit ? sortHeader.sortOnInit === 'asc' : true;
+        this.sortedBy = sortHeader.property;
+    }
+}
+
+export namespace ListHeaders {
+    'use strict';
+
+    export interface IStyle {
+        width: string;
+    }
+
+    export interface IHeader {
+        label: string;
+        property?: string;
+        styles?: IStyle;
+        sortOnInit?: ascOrder;
+    }
+    
+    export type ascOrder = 'asc' | 'desc';
+}


### PR DESCRIPTION
new list-headers component that uses table elements.

There is no change in functionality.