### PR TITLE
New Permissions Api

### DIFF
--- a/src/services/client/client.mock.ts
+++ b/src/services/client/client.mock.ts
@@ -91,7 +91,7 @@ export class ClientMock implements IClientBase {
                     role: [ { name: 'orgadmin', organization: 'abc' } ]
                 }
             },
-            '/organizations/abc/userroles/orgadmin/permissions': {
+            '/users/dimitri@apigee.com/permissions': {
                 value: {
                     resourcePermission: [ { organization: 'abc', path: '/', permissions: ['get', 'put', 'delete']} ]
                 }

--- a/src/services/client/observable-client.spec.ts
+++ b/src/services/client/observable-client.spec.ts
@@ -83,22 +83,14 @@ describe('Observable Client', () => {
         someObservableClient = new SomeObservableClient(client, router);
     });
 
-    it('Loading Permissions for current user', done => {
-        const rawRoles = {
-            role: [
-                { name: 'orgadmin', organization: 'abc' },
-                { name: 'custom', organization: 'abc' },
-                { name: 'orgadmin', organization: 'abcd' },
-            ]
-        };
+    it('Loading Permissions for current user and org', done => {
+
         const root = { organization: 'abc', path: '/path', permissions: ['get', 'put', 'delete']};
         const custom = { organization: 'abc', path: '/custom', permissions: ['get', 'put', 'delete']};
-        const orgAdmin = { resourcePermission: [root] };
-        const customRole = { resourcePermission: [custom] };
+        const otherOrgPerms = { organization: 'def', path: '/otherPath', permissions: []};
+        const response = { resourcePermission: [root, custom, otherOrgPerms] };
 
-        client.on('/users/dimitri@apigee.com/userroles', rawRoles);
-        client.on('/organizations/abc/userroles/orgadmin/permissions', orgAdmin);
-        client.on('/organizations/abc/userroles/custom/permissions', customRole);
+        client.on('/users/dimitri@apigee.com/permissions', response);
 
         someObservableClient.permissions().subscribe(
             permissions => {

--- a/src/services/client/observable-client.ts
+++ b/src/services/client/observable-client.ts
@@ -81,12 +81,11 @@ export abstract class ObservableClient extends ObservableClientBase {
     
     public permissions = (): Observable<RolePermissions> => {
         return this.userInfo()
-            .flatMap((info: IUserInfo) => this.get<IResourcePermissionsResponse>(this.router.permissions(info.email))
-                .map((response: IResourcePermissionsResponse) => {
-                    response.resourcePermission = response.resourcePermission
-                        .filter((p: IResourcePermissions) => p.organization === this.router.orgName);
-                    return response;
-                }))
+            .flatMap((info: IUserInfo) => this.get<IResourcePermissionsResponse>(this.router.permissions(info.email)))
+            .map((response: IResourcePermissionsResponse) => ({
+                resourcePermission: response.resourcePermission
+                    .filter((p: IResourcePermissions) => p.organization === this.router.orgName)
+            }))
             .map((response: IResourcePermissionsResponse) => new RolePermissions(response));
     };
 }

--- a/src/services/router/api-routes.ts
+++ b/src/services/router/api-routes.ts
@@ -20,4 +20,6 @@ export class ApiRoutes {
     public userRoles = (user: string): string => `/users/${user}/userroles`;
 
     public orgRole = (role: string): string => this.orgUrl(`/userroles/${role}/permissions`);
+    
+    public permissions = (email: string) => `/users/${email}/permissions`;
 }

--- a/src/services/storage/repository.spec.ts
+++ b/src/services/storage/repository.spec.ts
@@ -262,7 +262,7 @@ describe('EntityRepository', () => {
 
     it('Does not load entities and updates permissions if the user does not have permissions', (done) => {
         const errorMessage = 'Forbidden. You don\'t have permissions to access this resource. Error code: 403';
-        client.on('/organizations/abc/userroles/orgadmin/permissions', {
+        client.on('/users/dimitri@apigee.com/permissions', {
             resourcePermission: [ { organization: 'abc', path: '/', permissions: []} ]
         });
         client.on(`/organizations/abc/${apiBasePath}`, errorMessage, true);


### PR DESCRIPTION
```
Use alternate API to retrieve permissions in a single call, then filter for current org permissions.

Update client.mock default permissions response to use new api.
```

@gabyvs @wigahluk  I've tested alongside Proxies and the new permissions handling works there.  I also removed the private `userRoles` method from `ObservableClient` since it is no longer needed.