### PR TITLE
Fix case where filtering on pattern and field skips falsey values

### DIFF
--- a/src/services/storage/storage.spec.ts
+++ b/src/services/storage/storage.spec.ts
@@ -341,9 +341,10 @@ describe('Filters', () => {
     });
 
     it('Create Filter with pattern & field', () => {
-        const f = createDictionaryFilter<{ a?; some?; b?; }>('some', 'b');
-        expect(f({a: 'some'})).toBe(false);
-        expect(f({b: 'some'})).toBe(true);
+        const f = createDictionaryFilter<{ a?; some?; b?; }>('0', 'b');
+        expect(f({a: '0'})).toBe(false);
+        expect(f({b: '0'})).toBe(true);
+        expect(f({b: 0})).toBe(true);
     });
 
     it('Filters are case insensitive', () => {

--- a/src/services/storage/storage.ts
+++ b/src/services/storage/storage.ts
@@ -17,7 +17,7 @@ export const createDictionaryFilter = <T>(pattern?: string, field?: string): (d:
     }
     return <T extends Dictionary<{}>>(d: T) => {
         const v = _.get(d, fieldName);
-        return v ? v.toString().toLowerCase().indexOf(pattern.toLocaleLowerCase()) >= 0 : false;
+        return _.isUndefined(v) ? false : v.toString().toLowerCase().indexOf(pattern.toLocaleLowerCase()) >= 0;
     };
 };
 


### PR DESCRIPTION
```
Fix case where filtering on pattern and field skips falsey values
```

@gabyvs Looks like this logic was already in place for filtering with just a field name and no pattern, we just needed it in the case where user is filtering with both criteria as well.