### PR TITLE
Use `organization` query param in permissions call

### DIFF
--- a/src/services/client/client.mock.ts
+++ b/src/services/client/client.mock.ts
@@ -91,7 +91,7 @@ export class ClientMock implements IClientBase {
                     role: [ { name: 'orgadmin', organization: 'abc' } ]
                 }
             },
-            '/users/dimitri@apigee.com/permissions': {
+            '/users/dimitri@apigee.com/permissions?organization=abc': {
                 value: {
                     resourcePermission: [ { organization: 'abc', path: '/', permissions: ['get', 'put', 'delete']} ]
                 }

--- a/src/services/client/observable-client.spec.ts
+++ b/src/services/client/observable-client.spec.ts
@@ -90,7 +90,7 @@ describe('Observable Client', () => {
         const otherOrgPerms = { organization: 'def', path: '/otherPath', permissions: []};
         const response = { resourcePermission: [root, custom, otherOrgPerms] };
 
-        client.on('/users/dimitri@apigee.com/permissions', response);
+        client.on('/users/dimitri@apigee.com/permissions?organization=abc', response);
 
         someObservableClient.permissions().subscribe(
             permissions => {

--- a/src/services/client/observable-client.ts
+++ b/src/services/client/observable-client.ts
@@ -78,7 +78,11 @@ export abstract class ObservableClient extends ObservableClientBase {
 
     public getListObject = <T>(): Observable<T> =>
         this.get<T>(this.router.list());
-    
+
+    // MGMT-3977 EDGEUE-249 // TODO remove filtering logic when API is ready
+    // We are now passing an `organization` query param in this call in order to sidestep the MGMT-3977 bug, but API
+    // still returns all permissions for all orgs.  We have been advised to keep the filtering logic below until the
+    // API has been fixed to do this filtering on the backend.
     public permissions = (): Observable<RolePermissions> => {
         return this.userInfo()
             .flatMap((info: IUserInfo) => this.get<IResourcePermissionsResponse>(this.router.permissions(info.email)))

--- a/src/services/router/api-routes.ts
+++ b/src/services/router/api-routes.ts
@@ -21,5 +21,5 @@ export class ApiRoutes {
 
     public orgRole = (role: string): string => this.orgUrl(`/userroles/${role}/permissions`);
     
-    public permissions = (email: string) => `/users/${email}/permissions`;
+    public permissions = (email: string) => `/users/${email}/permissions?organization=${this.orgName}`;
 }

--- a/src/services/storage/repository.spec.ts
+++ b/src/services/storage/repository.spec.ts
@@ -262,7 +262,7 @@ describe('EntityRepository', () => {
 
     it('Does not load entities and updates permissions if the user does not have permissions', (done) => {
         const errorMessage = 'Forbidden. You don\'t have permissions to access this resource. Error code: 403';
-        client.on('/users/dimitri@apigee.com/permissions', {
+        client.on('/users/dimitri@apigee.com/permissions?organization=abc', {
             resourcePermission: [ { organization: 'abc', path: '/', permissions: []} ]
         });
         client.on(`/organizations/abc/${apiBasePath}`, errorMessage, true);


### PR DESCRIPTION
```
[EDGEUE-249] Use `organization` query param in permissions call to resolve MGMT-3977 bug.

API is in transitory state, see TODO in observable-client.ts.
```
@gabyvs pinging you with details.